### PR TITLE
fix: validate the authority instead of the whole href

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ const urlHttp = require('url-http')
 !!urlHttp('callto:192.168.103.77+type=ip') // ==> false
 ```
 
-If you need to run the package in a browser environment, you can save some bytes using the lightweight version:
+Beyond the scheme, it requires the host to be one the public internet can resolve: an IP literal, `localhost`, or a domain whose TLD is in the [public suffix list](https://github.com/stephenmathieson/node-tlds). Hosts such as `http://internal/` or `https://example.local/` are rejected, as are URLs carrying credentials.
+
+If you need to run the package in a browser environment, you can save some bytes using the lightweight version, which checks the scheme only:
 
 ```js
 const urlHttp = require('url-http/lightweight')

--- a/index.js
+++ b/index.js
@@ -1,61 +1,35 @@
 'use strict'
 
-const urlRegex = require('url-regex-safe')
+const tlds = require('tlds')
+const { domainToASCII } = require('node:url')
 
-const REGEX_URL_EXACT = urlRegex({
-  apostrophes: true,
-  exact: true,
-  parens: true
-})
-const REGEX_URL_LOOSE = urlRegex({
-  apostrophes: true,
-  exact: false,
-  parens: true
-})
+// The list stores IDN TLDs in Unicode (`рф`) but a WHATWG hostname is always
+// punycoded, so the comparison has to happen in ASCII.
+const PUBLIC_TLDS = new Set(tlds.map(tld => domainToASCII(tld)))
 
-// IANA's root zone lists ~151 xn-- TLDs; the bound keeps a caller-supplied one
-// from growing the cache without limit.
-const MAX_CACHED_IDN_TLDS = 256
-const idnRegexCache = new Map()
+const REGEX_IPV4_TLD = /^\d+$/
+const REGEX_LABELS =
+  /^[a-z\d](?:[a-z\d_-]*[a-z\d])?(?:\.[a-z\d](?:[a-z\d_-]*[a-z\d])?)*$/
 
-const idnRegex = tld => {
-  const cached = idnRegexCache.get(tld)
-  if (cached !== undefined) return cached
-  const regex = urlRegex({
-    apostrophes: true,
-    exact: true,
-    parens: true,
-    tlds: [tld]
-  })
-  if (idnRegexCache.size >= MAX_CACHED_IDN_TLDS) {
-    idnRegexCache.delete(idnRegexCache.keys().next().value)
-  }
-  idnRegexCache.set(tld, regex)
-  return regex
+const isPublicHostname = hostname => {
+  // The parser has already validated the IPv6 literal inside the brackets.
+  if (hostname[0] === '[') return true
+  if (hostname === 'localhost') return true
+
+  const tldIndex = hostname.lastIndexOf('.') + 1
+  const tld = hostname.slice(tldIndex)
+
+  // A numeric last label means the parser resolved the whole host as IPv4.
+  if (REGEX_IPV4_TLD.test(tld)) return true
+
+  return tldIndex > 0 && PUBLIC_TLDS.has(tld) && REGEX_LABELS.test(hostname)
 }
 
 module.exports = url => {
   try {
-    const parsedUrl = new URL(url)
-    const { href, hostname, protocol, username, password } = parsedUrl
+    const { href, hostname, protocol, username, password } = new URL(url)
     if ((protocol !== 'http:' && protocol !== 'https:') || username || password) { return false }
-
-    // url-regex-safe cannot exact-match IPv6 authorities.
-    if (hostname[0] === '[') {
-      // Matching the whole href would succeed on a URL-looking substring in the
-      // path, leaving the authority unchecked (`http://internal/https://example.com/`).
-      REGEX_URL_LOOSE.lastIndex = 0
-      return REGEX_URL_LOOSE.test(`${parsedUrl.origin}/`) && href
-    }
-
-    // url-regex-safe's TLD list has no xn-- entries, so an IDN TLD has to be
-    // supplied; an ASCII one stays subject to the built-in public-suffix list.
-    const tldIndex = hostname.lastIndexOf('.') + 1
-    const regex = hostname.startsWith('xn--', tldIndex)
-      ? idnRegex(hostname.slice(tldIndex))
-      : REGEX_URL_EXACT
-
-    return regex.test(href) && href
+    return isPublicHostname(hostname) && href
   } catch {
     return false
   }

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "whatwg"
   ],
   "dependencies": {
-    "re2": "~1.26.0",
-    "url-regex-safe": "~4.0.0"
+    "tlds": "~1.261.0"
   },
   "devDependencies": {
     "@commitlint/cli": "latest",

--- a/test/index.js
+++ b/test/index.js
@@ -23,7 +23,13 @@ const test = require('ava').default
       'http://www.kikobeats.com',
       'https://example.xn--p1ai',
       'https://xn--80a0aaa.com',
-      'https://xn--80a0aaa.xn--p1ai'
+      'https://xn--80a0aaa.xn--p1ai',
+      'http://localhost:3000/',
+      'http://0.0.0.0:1/',
+      'https://sub.dom_ain.example.com/',
+      'https://example.com/a.',
+      'https://example.com/?q=1.',
+      'https://example.com/#x!'
     ].forEach(input => {
       const url = httpUrl(input)
       t.is(typeof url, 'string', `'${input}' is not true`)
@@ -64,7 +70,12 @@ const test = require('ava').default
         'https://xn--e1afmkfd.local/',
         'https://пример.local/',
         'https://xn--80a0aaa.internal/',
-        'https://xn--80a0aaa.invalidtld/'
+        'https://xn--80a0aaa.invalidtld/',
+        'https://xn--80a0aaa.xn--totallyfaketld/',
+        'https://xn--80a0aaa.ñ/',
+        'https://kikobeats.com./',
+        'https://a-.com/',
+        'https://_dmarc.example.com/'
       ])
     ).forEach(input => {
       const url = httpUrl(input)
@@ -74,10 +85,9 @@ const test = require('ava').default
   })
 })
 
-test('IDN TLD regexes survive cache eviction', t => {
+test('an IDN TLD is matched by its punycode form', t => {
   const httpUrl = require('..')
-  t.is(httpUrl('https://xn--80a0aaa.xn--p1ai'), 'https://xn--80a0aaa.xn--p1ai/')
-  for (let i = 0; i < 300; i++) httpUrl(`https://example.xn--junk${i}`)
-  t.is(httpUrl('https://xn--80a0aaa.xn--p1ai'), 'https://xn--80a0aaa.xn--p1ai/')
-  t.is(httpUrl('https://xn--80a0aaa.invalidtld/'), false)
+  t.is(httpUrl('https://example.рф'), 'https://example.xn--p1ai/')
+  t.is(httpUrl('https://example.xn--p1ai'), 'https://example.xn--p1ai/')
+  t.is(httpUrl('https://example.xn--p1a'), false)
 })


### PR DESCRIPTION
## What

`new URL()` already applies IDNA, IPv4/IPv6 validation and percent-encoding. The only question it leaves open is whether the host is one the public internet can resolve. This answers that directly instead of round-tripping the normalized `href` back through `url-regex-safe`, a matcher built to find URLs inside prose.

```js
const isPublicHostname = hostname => {
  if (hostname[0] === '[') return true          // parser validated the IPv6 literal
  if (hostname === 'localhost') return true

  const tldIndex = hostname.lastIndexOf('.') + 1
  const tld = hostname.slice(tldIndex)
  if (REGEX_IPV4_TLD.test(tld)) return true     // parser resolved the host as IPv4

  return tldIndex > 0 && PUBLIC_TLDS.has(tld) && REGEX_LABELS.test(hostname)
}
```

## Why

**It closes a hole #32 could not close.** `url-regex-safe`'s TLD list stores IDN TLDs in Unicode (`рф`) and holds zero `xn--` entries, so #32 had to hand the regex the host's own TLD — a check that passes by construction. `https://xn--80a0aaa.xn--totallyfaketld/` was accepted on `master` and no amount of tuning that branch would reject it. Mapping the list to punycode once at load makes the punycode case fall out for free rather than needing a special case.

**The special cases collapse.** The IPv6 exact-match exception (#30), the TLD injection (#32) and the second origin-only pass (#31) were three bandaids on the same mismatch. All three are gone, and with them `url-regex-safe` and the `re2` native binding. `tlds` becomes a direct dependency; it was already transitive.

**The path check was doing harm.** Every character in `url-regex-safe`'s `disallowedChars` is already percent-encoded or stripped by WHATWG normalization, and `parens: true` / `apostrophes: true` were passed precisely to disable the two checks that survive. What was left rejected ordinary URLs — see the behavior changes below.

## Behavior changes

Fuzz-differentialled against `master` over 300k inputs. Every divergence falls in one of four classes, zero unclassified:

| | before | after |
|---|---|---|
| `https://example.com/a.`, `/?q=1.`, `/#x!` | `false` | accepted |
| `http://example.com:1/` (ports below 10) | `false` | accepted |
| `http://x.a_b.com/` (underscore outside a bare second-level label) | `false` | accepted |
| `https://xn--80a0aaa.xn--totallyfaketld/`, `https://xn--80a0aaa.ñ/` | accepted | `false` |

The first three are `url-regex-safe` artifacts, not intent — it forbids a trailing `. ? !` because in prose that is sentence punctuation, and it accepted `a_b.com` while rejecting `x.a_b.com`. The fourth is the fix. Minor release, not a patch.

## Performance

| | before | after |
|---|---|---|
| ordinary host | 21.6µs | 0.29µs |
| punycode host | 3.8µs | 0.34µs |
| IPv6 host | 22.5µs | 0.22µs |

`master` compiled a fresh RE2 regex on every call; construction was ~99% of the work. Require time is 3.9ms, dominated by a one-time ICU init that the first non-ASCII `new URL()` would pay anyway.

`REGEX_LABELS` has no cross-group ambiguity (labels are separated by a mandatory literal `.`) and backtracks linearly within a label. Probed to 200k chars on backtrack-forcing inputs — linear, no cliff. It does not need RE2.

## Tests

`npx ava` — 5 pass. New cases: `localhost:3000`, `0.0.0.0:1`, `sub.dom_ain.example.com`, the three trailing-punctuation paths, `xn--80a0aaa.xn--totallyfaketld`, `xn--80a0aaa.ñ`, `kikobeats.com.`, `a-.com`, `_dmarc.example.com`, plus a test that an IDN TLD is matched by its punycode form.

## Note, not in this PR

`package.json` declares `"types": "src/index.d.ts"` but the file ships at `index.d.ts`, so TypeScript consumers get no types. Pre-existing on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3AcnZdy222rWCkptbywJT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes URL acceptance rules for security-sensitive validation; fixes prior false positives but alters which URLs pass (paths with punctuation, underscore subdomains, low ports).
> 
> **Overview**
> Replaces **`url-regex-safe`** and **`re2`** with **`isPublicHostname`**: after `new URL()` enforces http(s) and no credentials, acceptance depends on whether the host is IPv6, `localhost`, IPv4, or a domain whose punycode TLD is in the **`tlds`** public list, with **`REGEX_LABELS`** guarding hostname shape.
> 
> This closes the fake-IDN-TLD hole (e.g. `xn--totallyfaketld`) and drops the IPv6/IDN regex workarounds. **Intentional behavior shifts:** more real URLs with trailing `.`, `?`, or `!` in path/query/fragment are accepted; fake TLDs, trailing-dot hosts, and some invalid labels are rejected. README documents the public-host rule; tests cover the new cases and punycode IDN TLD matching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e48e57805880e6d6cd7570cc4c4fd78b60265ae9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->